### PR TITLE
fix set project-id script

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ All of the code is organized into folders and subfolders corresponding to each c
 You will have to replace the string <code>\<PROJECT-ID\></code> with the project id of your Google Cloud Project. To faciliate that, we have included a small <code>bash</code> script sets the Google Cloud project recursively.
  
 ```
-./set-project-id <PROJECT_ID>
+./set-project-id <PROJECT_ID>   (for Mac, use ./set-project-id-mac)
 ```
 replaces all occurances of <code>\<PROJECT-ID\></code> in all files to <code><PROJECT_ID></code>. Whereas the <code>-u</code> flag undoes the replacement, that is replacing all occurances back  <code>\<PROJECT-ID\></code>
 

--- a/set-project-id
+++ b/set-project-id
@@ -3,7 +3,7 @@
 while getopts 'uh' OPTION; do
   case "$OPTION" in
     u)
-        grep  -lrnw  . -e $2 --exclude terraform.tfstate* --exclude set-project-id --exclude-dir .terraform \
+        grep  -lrnw  . -e $2 --exclude terraform.tfstate* --exclude set-project-id* --exclude-dir .terraform \
 | xargs -i@ sed -i s/$2/\<PROJECT_ID\>/g @
     exit 1
     ;;
@@ -14,5 +14,5 @@ while getopts 'uh' OPTION; do
     esac
     done
 
-grep  -lrnw  . -e "<PROJECT_ID>" --exclude terraform.tfstate* --exclude set-project-id --exclude-dir .terraform \
+grep  -lrnw  . -e "<PROJECT_ID>" --exclude terraform.tfstate* --exclude set-project-id* --exclude-dir .terraform \
 | xargs -i@ sed -i s/\<PROJECT_ID\>/$1/g @

--- a/set-project-id
+++ b/set-project-id
@@ -3,7 +3,7 @@
 while getopts 'uh' OPTION; do
   case "$OPTION" in
     u)
-        grep  -lrnw  . -e $2 --exclude terraform.tfstate* --exclude-dir .terraform \
+        grep  -lrnw  . -e $2 --exclude terraform.tfstate* --exclude set-project-id --exclude-dir .terraform \
 | xargs -i@ sed -i s/$2/\<PROJECT_ID\>/g @
     exit 1
     ;;

--- a/set-project-id-mac
+++ b/set-project-id-mac
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+while getopts 'uh' OPTION; do
+  case "$OPTION" in
+    u)
+        grep  -lrnw  . -e $2 --exclude terraform.tfstate* --exclude-dir set-project-id* --exclude-dir .terraform \
+| xargs -I@ sed -i '' "s/$2/\<PROJECT_ID\>/g" @
+    exit 1
+    ;;
+    h)
+        echo "set-project-id [-uh] project-id $2"
+        exit 1
+        ;;
+    esac
+    done
+
+grep  -lrnw  . -e "<PROJECT_ID>" --exclude terraform.tfstate* --exclude set-project-id* --exclude-dir .terraform \
+| xargs -I@ sed -i '' "s/\<PROJECT_ID\>/$1/g" @


### PR DESCRIPTION
For mac platform, the arguments of xargs and sed have to be changed slightly. Also excluded the set-project-id* files from set-project-id script evaluation.