### PR TITLE
Add project id to provider

### DIFF
--- a/chap02/state-file/provider.tf
+++ b/chap02/state-file/provider.tf
@@ -1,4 +1,5 @@
 provider "google" {
   region = var.region
   zone   = var.zone
+  project = var.project_id
 }


### PR DESCRIPTION
Fixes
tofu apply
╷
│ Error: 1 error occurred:
│       * Failed to retrieve project, pid: , err: project: required field is not set
│ 
│ 
│ 
│   with google_compute_instance.this,
│   on main.tf line 1, in resource "google_compute_instance" "this":
│    1: resource "google_compute_instance" "this" {
│ 
╵